### PR TITLE
Sum quantities together, when possible

### DIFF
--- a/src/list.spec.ts
+++ b/src/list.spec.ts
@@ -1,5 +1,6 @@
 import { readList, calculateGeneratedList, updateGeneratedList, GeneratedList } from "./list";
 import { resizeRecipe, type Recipe } from "./recipe";
+import { reduceQuantities } from "./quantity";
 
 describe("list", () => {
   beforeEach(() => {
@@ -65,10 +66,12 @@ describe("list", () => {
 
     beforeEach(() => {
       (global as any).resizeRecipe = resizeRecipe;
+      (global as any).reduceQuantities = reduceQuantities;
     });
 
     afterEach(() => {
       delete (global as any).resizeRecipe;
+      delete (global as any).reduceQuantities;
     });
 
     it("should expand recipes and deduplicate articles", () => {
@@ -78,14 +81,14 @@ describe("list", () => {
 
     it("should scale and combine quantity fields of redundant items", () => {
       const generatedList = calculateGeneratedList(recipesByName, list);
-      expect(generatedList["Pain"].quantity).toBe("300g|50g|600g");
+      expect(generatedList["Pain"].quantity).toBe("950g");
     });
 
     it("should leave the other quantity fields uncombined", () => {
       const generatedList = calculateGeneratedList(recipesByName, list);
       expect(generatedList["Eau"].quantity).toBe("");
       expect(generatedList["Brioche"].quantity).toBe("1kg");
-      expect(generatedList["Confiture"].quantity).toBe("30ml");
+      expect(generatedList["Confiture"].quantity).toBe("3cl");
     });
 
     it("should mark articles as unchecked", () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,4 +1,5 @@
 import type { getAllRecipesByName as GetAllRecipesByName, resizeRecipe as ResizeRecipe, Recipe } from "./recipe";
+import type { reduceQuantities as ReduceQuantities } from "./quantity";
 
 export type List = ListItem[];
 export type ListItem = {
@@ -15,6 +16,7 @@ export type GeneratedListItem = {
 
 declare const getAllRecipesByName: typeof GetAllRecipesByName;
 declare const resizeRecipe: typeof ResizeRecipe;
+declare const reduceQuantities: typeof ReduceQuantities;
 
 export function calculateAndUpdateGeneratedList(spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet) {
   const recipesByName = getAllRecipesByName(spreadsheet);
@@ -34,7 +36,7 @@ export function calculateGeneratedList(recipesByName: Record<string, Recipe>, li
     .reduce((acc, item) => ({
       ...acc,
       [item.name]: {
-        quantity: acc[item.name] ? `${acc[item.name].quantity}|${item.quantity}` : item.quantity,
+        quantity: reduceQuantities(acc[item.name]?.quantity || "", item.quantity),
         checked: false,
       },
     }), {});

--- a/src/quantity.spec.ts
+++ b/src/quantity.spec.ts
@@ -1,0 +1,115 @@
+import { reduceQuantities, serializeMilligrams, serializeMilliliters } from "./quantity";
+
+const error = console.error;
+
+beforeEach(() => {
+  global.console.error = jest.fn();
+});
+
+afterEach(() => {
+  global.console.error = error;
+});
+
+describe("quantity", () => {
+  describe("reduceQuantities", () => {
+    it("Nothin’ from nothin’ leaves nothin’", () => {
+      expect(reduceQuantities("", "")).toBe("");
+    });
+
+    it("Nothin’ plus something is something", () => {
+      expect(reduceQuantities("", "450g")).toBe("450g");
+    });
+
+    it("should sum up two countables", () => {
+      expect(reduceQuantities("4", "5")).toBe("9");
+    });
+
+    it("should sum up two volumes", () => {
+      expect(reduceQuantities("4l", "0.5l")).toBe("4.5l");
+    });
+
+    it("should sum up two volumes of different units", () => {
+      expect(reduceQuantities("4cl", "1 c-à-s")).toBe("5.5cl");
+    });
+
+    it("should sum up two weights", () => {
+      expect(reduceQuantities("4mg", "9mg")).toBe("13mg");
+    });
+
+    it("should sum up two weights of different units", () => {
+      expect(reduceQuantities("4mg", "9g")).toBe("9.01g");
+    });
+
+    it("should combine two quantities of different types", () => {
+      expect(reduceQuantities("4l", "3g")).toBe("4l|3g");
+    });
+
+    it("should handle unknown units", () => {
+      expect(reduceQuantities("4l|3 pieces", "8 parts")).toBe("4l|3 pieces|8 parts");
+    });
+
+    it("should add to the correct existing unit", () => {
+      expect(reduceQuantities("1l|32g|5|12 pieces", "540mg")).toBe("1l|32.54g|5|12 pieces");
+    });
+  });
+
+  describe("serializeMilliliters", () => {
+    ([
+      [0.01, "0.01ml"],
+      [0.1, "0.1ml"],
+      [1, "1ml"],
+      [10, "1cl"],
+      [100, "1dl"],
+      [1000, "1l"],
+      [10000, "10l"],
+      [100000, "100l"],
+    ] as const).forEach(([input, output]) => it(`should serialize ${input} to ${output}`, () => {
+      expect(serializeMilliliters(input)).toBe(output);
+    }));
+
+    ([
+      [0.001, "0.01ml"],
+      [0.123, "0.13ml"],
+      [1.345, "1.35ml"],
+      [10.67, "1.07cl"],
+      [100.4, "1.01dl"],
+      [1038, "1.04l"],
+      [10026, "10.03l"],
+      [100123, "100.13l"],
+    ] as const).forEach(([input, output]) => it(`should serialize ${input} to ${output} (keep 2 digits after the decimal point)`, () => {
+      expect(serializeMilliliters(input)).toBe(output);
+    }));
+  });
+
+  describe("serializeMilligrams", () => {
+    ([
+      [0.01, "0.01mg"],
+      [0.1, "0.1mg"],
+      [1, "1mg"],
+      [10, "10mg"],
+      [100, "100mg"],
+      [1000, "1g"],
+      [10000, "10g"],
+      [100000, "100g"],
+      [1000000, "1kg"],
+      [10000000, "10kg"],
+      [100000000, "100kg"],
+    ] as const).forEach(([input, output]) => it(`should serialize ${input} to ${output}`, () => {
+      expect(serializeMilligrams(input)).toBe(output);
+    }));
+
+    ([
+      [0.001, "0.01mg"],
+      [0.123, "0.13mg"],
+      [1.345, "1.35mg"],
+      [10.674, "10.68mg"],
+      [100.4, "100.4mg"],
+      [1038, "1.04g"],
+      [10026, "10.03g"],
+      [100123, "100.13g"],
+      [1012141, "1.02kg"],
+    ] as const).forEach(([input, output]) => it(`should serialize ${input} to ${output} (keep 2 digits after the decimal point)`, () => {
+      expect(serializeMilligrams(input)).toBe(output);
+    }));
+  });
+});

--- a/src/quantity.ts
+++ b/src/quantity.ts
@@ -1,0 +1,178 @@
+export type Quantity = number | string;
+
+type Countable = {
+  type: "countable";
+  count: number;
+  unit: undefined;
+};
+
+const volumeUnits = ["ml", "c-à-c", "cl", "c-à-s", "dl", "l"] as const;
+
+type VolumeUnit = (typeof volumeUnits)[number];
+type Volume = {
+  type: "volume";
+  count: number;
+  unit: VolumeUnit;
+};
+
+const weightUnits = ["mg", "g", "kg"] as const;
+
+type WeightUnit = (typeof weightUnits)[number];
+type Weight = {
+  type: "weight";
+  count: number;
+  unit: WeightUnit;
+};
+
+type ParsedQuantity = Countable | Volume | Weight;
+type ParsedQuantities = Record<ParsedQuantity["type"], number> & {
+  unknown?: string[];
+};
+
+export function reduceQuantities(acc: string, quantity: Quantity): string {
+  const quantities = addQuantity(parseQuantities(acc), parseQuantity(quantity));
+  return Object.entries(quantities).flatMap(([key, value]) => {
+    switch (key) {
+      case "countable":
+        return [(value as ParsedQuantities["countable"]).toString()];
+      case "volume":
+        return [serializeMilliliters(value as ParsedQuantities["volume"])];
+      case "weight":
+        return [serializeMilligrams(value as ParsedQuantities["weight"])];
+      case "unknown":
+        return (value as ParsedQuantities["unknown"]);
+    }
+  })
+    .filter(item => item)
+    .join("|");
+}
+
+function parseQuantities(value: string): ParsedQuantities {
+  return value.split("|").reduce((acc, item) => addQuantity(acc, parseQuantity(item)), {} as ParsedQuantities);
+}
+
+function addQuantity(quantities: ParsedQuantities, quantity: ParsedQuantity | string): ParsedQuantities {
+  if (typeof quantity === "string") {
+    return {
+      ...quantities,
+      unknown: (quantities.unknown || []).concat(quantity),
+    };
+  }
+
+  switch (quantity.type) {
+    case "countable":
+      return {
+        ...quantities,
+        countable: (quantities.countable || 0) + quantity.count,
+      };
+    case "volume":
+      return {
+        ...quantities,
+        volume: (quantities.volume || 0) + quantity.count,
+      };
+    case "weight":
+      return {
+        ...quantities,
+        weight: (quantities.weight || 0) + quantity.count,
+      };
+  }
+}
+
+function toMilliliters(count: number, unit: VolumeUnit): number {
+  switch (unit) {
+    case "ml":
+      return count;
+    case "c-à-c":
+      return count * 5;
+    case "cl":
+      return count * 10;
+    case "c-à-s":
+      return count * 15;
+    case "dl":
+      return count * 100;
+    case "l":
+      return count * 1000;
+  }
+}
+
+export function serializeMilliliters(count: number): string {
+  if (count >= 1000) {
+    return `${Math.ceil(count / 10) / 100}l`;
+  }
+
+  if (count >= 100) {
+    return `${Math.ceil(count) / 100}dl`;
+  }
+
+  if (count >= 10) {
+    return `${Math.ceil(count * 10) / 100}cl`;
+  }
+
+  return `${Math.ceil(count * 100) / 100}ml`;
+}
+
+function toMilligrams(count: number, unit: WeightUnit): number {
+  switch (unit) {
+    case "mg":
+      return count;
+    case "g":
+      return 1000 * count;
+    case "kg":
+      return 1000000 * count;
+  }
+}
+
+export function serializeMilligrams(count: number): string {
+  if (count >= 1000000) {
+    return `${Math.ceil(100 * count / 1000 / 1000) / 100}kg`;
+  }
+
+  if (count >= 1000) {
+    return `${Math.ceil(100 * count / 1000) / 100}g`;
+  }
+
+  return `${Math.ceil(100 * count) / 100}mg`;
+}
+
+function parseQuantity(value: Quantity): string | ParsedQuantity {
+  if (typeof value === "number") {
+    return { type: "countable", count: value, unit: undefined };
+  }
+
+  if (value === "") {
+    return "";
+  }
+
+  const result = value.match(/^([0-9.]+)\s*(\S*)$/);
+
+  if (result === null) {
+    console.warn(`Unrecognized quantity: ${value}.`);
+    return value;
+  }
+
+  const [_, countString, unit] = result;
+  const count = parseFloat(countString);
+
+  if (unit === "") {
+    return { type: "countable", count, unit: undefined };
+  }
+
+  if (isVolumeUnit(unit)) {
+    return { type: "volume", count: toMilliliters(count, unit), unit: "ml" };
+  }
+
+  if (isWeightUnit(unit)) {
+    return { type: "weight", count: toMilligrams(count, unit), unit: "mg" };
+  }
+
+  console.error(`Unrecognized unit: ${unit}.`);
+  return value;
+}
+
+function isVolumeUnit(unit: string): unit is VolumeUnit {
+  return (volumeUnits as readonly string[]).indexOf(unit) >= 0;
+}
+
+function isWeightUnit(unit: string): unit is WeightUnit {
+  return (weightUnits as readonly string[]).indexOf(unit) >= 0;
+}

--- a/src/recipe.spec.ts
+++ b/src/recipe.spec.ts
@@ -55,7 +55,7 @@ describe("recipe", () => {
       });
     });
 
-    it("should round string quantity values with a precision of two digits after the comma", () => {
+    it("should round string quantity values with a precision of two digits after the decimal point", () => {
       expect(resizeRecipe(RECIPE, "2p")).toStrictEqual({
         name: "Recipe 1",
         people: "2p",
@@ -68,6 +68,27 @@ describe("recipe", () => {
         }, {
           name: "Onions",
           quantity: 1 / 3,
+        }],
+      });
+    });
+
+    it("should handle decimal values as an input too", () => {
+      const recipe = { ...RECIPE, ingredients: RECIPE.ingredients.concat([{ name: "Milk", quantity: "0.5 dl" }]) };
+      expect(resizeRecipe(recipe, "6p")).toStrictEqual({
+        name: "Recipe 1",
+        people: "6p",
+        ingredients: [{
+          name: "Cheese",
+          quantity: "300g",
+        }, {
+          name: "Crème Fraîche",
+          quantity: "2 c-à-s",
+        }, {
+          name: "Onions",
+          quantity: 1,
+        }, {
+          name: "Milk",
+          quantity: "0.5 dl",
         }],
       });
     });

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -96,7 +96,7 @@ function resizeIngredient(ingredient: Ingredient, ratio: number): Ingredient {
     return {
       ...ingredient,
       quantity: ingredient.quantity.replace(/^([0-9,.]+)/, (_, num) => {
-        return (Math.round(parseInt(num, 10) * ratio * 100) / 100).toString();
+        return (Math.round(parseFloat(num) * ratio * 100) / 100).toString();
       }) as Quantity,
     };
   }


### PR DESCRIPTION
Specific support has been added for:
- volumes (`ml`, `c-à-c`, `cl`, `c-à-s`, `dl`, `l`)
- weights (`mg`, `g`, `kg`)
- "countables" (no specific units)