### PR TITLE
Handle conversion between different units

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "author": "Rodolphe Belouin <rodolphe.belouin@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "rollup -c",
+    "scripts:publish": "yarn build && clasp push"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.23.9",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,12 @@ function init() {
 function sortAndFormatRecipes() {
   Recipe.sortAndFormatRecipes();
 }
+
+function listIngredientsWithMultipleDimensions(): string {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  const recipes = Object.values(Recipe.getAllRecipesByName(spreadsheet));
+  const ingredients = Recipe.listIngredientsWithMultipleDimensions(recipes);
+
+  return "The following ingredients have quantities with various dimensions:\n" +
+    ingredients.map((ingredient) => `- ${ingredient.name} (${ingredient.quantity.dimensions()})`).join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ function listIncompleteIngredients(): string {
       return [`${ingredient.name} does not have a price in the selected store`];
     }
 
-    const quantity = Quantity.parse(ingredient.quantity.toString());
+    const quantity = Quantity.parse(ingredient.quantity?.toString());
     if (!quantity) {
       return [];
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import * as OnChange from "./onChange";
 import * as Init from "./init";
 import * as Recipe from "./recipe";
+import * as Stores from "./stores";
+import { Quantity } from "./quantities";
 
 function onChange() {
   OnChange.onChange();
@@ -14,11 +16,40 @@ function sortAndFormatRecipes() {
   Recipe.sortAndFormatRecipes();
 }
 
-function listIngredientsWithMultipleDimensions(): string {
+function listIncompleteIngredients(): string {
   const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
   const recipes = Object.values(Recipe.getAllRecipesByName(spreadsheet));
-  const ingredients = Recipe.listIngredientsWithMultipleDimensions(recipes);
+  const articlesByName = Stores.getStoreArticles(spreadsheet);
 
-  return "The following ingredients have quantities with various dimensions:\n" +
-    ingredients.map((ingredient) => `- ${ingredient.name} (${ingredient.quantity.dimensions()})`).join("\n");
+  const recipeIngredients = recipes.flatMap(recipe => recipe.ingredients);
+  const problems = recipeIngredients.flatMap(ingredient => {
+    const article = articlesByName[ingredient.name];
+    if (!article) {
+      return [`${ingredient.name} does not exist in the selected store`];
+    }
+
+    if (!article.price) {
+      return [`${ingredient.name} does not have a price in the selected store`];
+    }
+
+    const quantity = Quantity.parse(ingredient.quantity.toString());
+    if (!quantity) {
+      return [];
+    }
+
+    try {
+      quantity.conversions = article.price.quantity.conversions;
+      article.price.quantity.add(quantity);
+      return [];
+    } catch (err) {
+      return [`The quantity of ${ingredient.name} (${ingredient.quantity}) could not be converted`];
+    }
+  });
+
+
+  console.log("The following ingredients have configuration problems:\n" +
+    problems.map((problem) => `- ${problem}`).join("\n"));
+
+  return "The following ingredients have configuration problems:\n" +
+    problems.map((problem) => `- ${problem}`).join("\n");
 }

--- a/src/list.spec.ts
+++ b/src/list.spec.ts
@@ -1,4 +1,5 @@
 import { readList, calculateGeneratedList, updateGeneratedList, GeneratedList } from "./list";
+import { MixedQuantities } from "./quantities";
 import { type Recipe } from "./recipe";
 
 jest.mock("./init", () => {
@@ -33,9 +34,9 @@ describe("list", () => {
       } as Partial<GoogleAppsScript.Spreadsheet.Spreadsheet>;
 
       expect(readList(spreadsheet as any)).toStrictEqual([
-        { name: "Pain", quantity: "300g" },
-        { name: "Eau", quantity: "" },
-        { name: "Brioche", quantity: "1kg" },
+        { name: "Pain", quantity: MixedQuantities.parse("300g") },
+        { name: "Eau", quantity: MixedQuantities.parse("") },
+        { name: "Brioche", quantity: MixedQuantities.parse("1kg") },
       ]);
     });
   });
@@ -47,20 +48,20 @@ describe("list", () => {
         people: "4p",
         ingredients: [{
           name: "Pain",
-          quantity: "100g",
+          quantity: MixedQuantities.parse("100g"),
         }, {
           name: "Confiture",
-          quantity: "60ml",
+          quantity: MixedQuantities.parse("60ml"),
         }],
       },
     } as Record<string, Recipe>;
 
     const list = [
-      { name: "Pain", quantity: "300g" },
-      { name: "Tartines", quantity: "2p" },
-      { name: "Eau", quantity: "" },
-      { name: "Brioche", quantity: "1kg" },
-      { name: "Pain", quantity: "600g" },
+      { name: "Pain", quantity: MixedQuantities.parse("300g") },
+      { name: "Tartines", quantity: MixedQuantities.parse("2p") },
+      { name: "Eau", quantity: MixedQuantities.parse("") },
+      { name: "Brioche", quantity: MixedQuantities.parse("1kg") },
+      { name: "Pain", quantity: MixedQuantities.parse("600g") },
     ];
 
     it("should expand recipes and deduplicate articles", () => {

--- a/src/list.spec.ts
+++ b/src/list.spec.ts
@@ -1,5 +1,5 @@
 import { readList, calculateGeneratedList, updateGeneratedList, GeneratedList } from "./list";
-import { MixedQuantities } from "./quantities";
+import { Quantity } from "./quantities";
 import { type Recipe } from "./recipe";
 
 jest.mock("./init", () => {
@@ -34,9 +34,9 @@ describe("list", () => {
       } as Partial<GoogleAppsScript.Spreadsheet.Spreadsheet>;
 
       expect(readList(spreadsheet as any)).toStrictEqual([
-        { name: "Pain", quantity: MixedQuantities.parse("300g") },
-        { name: "Eau", quantity: MixedQuantities.parse("") },
-        { name: "Brioche", quantity: MixedQuantities.parse("1kg") },
+        { name: "Pain", quantity: Quantity.parse("300g") },
+        { name: "Eau", quantity: Quantity.parse("") },
+        { name: "Brioche", quantity: Quantity.parse("1kg") },
       ]);
     });
   });
@@ -48,20 +48,20 @@ describe("list", () => {
         people: "4p",
         ingredients: [{
           name: "Pain",
-          quantity: MixedQuantities.parse("100g"),
+          quantity: Quantity.parse("100g"),
         }, {
           name: "Confiture",
-          quantity: MixedQuantities.parse("60ml"),
+          quantity: Quantity.parse("60ml"),
         }],
       },
     } as Record<string, Recipe>;
 
     const list = [
-      { name: "Pain", quantity: MixedQuantities.parse("300g") },
-      { name: "Tartines", quantity: MixedQuantities.parse("2p") },
-      { name: "Eau", quantity: MixedQuantities.parse("") },
-      { name: "Brioche", quantity: MixedQuantities.parse("1kg") },
-      { name: "Pain", quantity: MixedQuantities.parse("600g") },
+      { name: "Pain", quantity: Quantity.parse("300g") },
+      { name: "Tartines", quantity: Quantity.parse("2p") },
+      { name: "Eau", quantity: Quantity.parse("") },
+      { name: "Brioche", quantity: Quantity.parse("1kg") },
+      { name: "Pain", quantity: Quantity.parse("600g") },
     ];
 
     it("should expand recipes and deduplicate articles", () => {

--- a/src/list.ts
+++ b/src/list.ts
@@ -7,9 +7,8 @@ import { GENERATED_LIST_SHEET_ARTICLE_RANGE, GENERATED_LIST_SHEET_NAME, GENERATE
 export type List = ListItem[];
 export type ListItem = {
   name: string;
-  quantity: Quantity;
+  quantity: MixedQuantities;
 }
-export type Quantity = number | string;
 
 export type GeneratedList = Record<ListItem["name"], GeneratedListItem>;
 export type GeneratedListItem = {
@@ -28,17 +27,17 @@ export function calculateAndUpdateGeneratedList(spreadsheet: GoogleAppsScript.Sp
 
 export function readList(spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet): List {
   const range = spreadsheet.getRange(`${LIST_SHEET_NAME}!${LIST_SHEET_ARTICLE_RANGE}`);
-  return range.getValues().flatMap(([name, quantity]) => name ? [{ name, quantity }] : []);
+  return range.getValues().flatMap(([name, quantity]) => name ? [{ name, quantity: MixedQuantities.parse(quantity) }] : []);
 }
 
 export function calculateGeneratedList(recipesByName: Record<string, Recipe>, list: List): GeneratedList {
   const generatedList = list
     .flatMap(item => recipesByName[item.name]
-      ? resizeRecipe(recipesByName[item.name], item.quantity as `${number}p`).ingredients
+      ? resizeRecipe(recipesByName[item.name], item.quantity.toString() as `${number}p`).ingredients
       : [item])
     .reduce((acc, item) => ({
       ...acc,
-      [item.name]: MixedQuantities.parse(item.quantity).add(acc[item.name]),
+      [item.name]: item.quantity.add(acc[item.name]),
     }), {} as Record<string, MixedQuantities>);
 
   return Object.fromEntries(Object.entries(generatedList)

--- a/src/price.spec.ts
+++ b/src/price.spec.ts
@@ -105,30 +105,6 @@ describe("price", () => {
   describe("getTotalPriceForQuantity", () => {
     [
       {
-        priceQuantity: Quantity.from(4),
-        quantity: MixedQuantities.from(4, "ml"),
-      },
-      {
-        priceQuantity: Quantity.from(5, "ml"),
-        quantity: MixedQuantities.from(5, "kg"),
-      },
-      {
-        priceQuantity: Quantity.from(6, "mg"),
-        quantity: MixedQuantities.from(6),
-      },
-    ].forEach(({ priceQuantity, quantity }) => {
-      it(`should return "undefined" if quantities are not of the same dimension. e.g. ${priceQuantity} != ${quantity}`, () => {
-        expect(
-          getTotalPriceForQuantity(
-            { value: 4, currency: "kr", quantity: priceQuantity },
-            quantity,
-          ),
-        ).toBeUndefined();
-      });
-    });
-
-    [
-      {
         price: {
           value: 4,
           currency: "kr",
@@ -147,10 +123,73 @@ describe("price", () => {
         expectedPrice: { value: 16.67, currency: "€" },
       },
     ].forEach(({ price, quantity, expectedPrice }, index) => {
-      it(`should return the total price otherwise. #${index}`, () => {
+      it(`should return the total price for compatible types. #${index}`, () => {
         expect(getTotalPriceForQuantity(price, quantity)).toEqual(
           expectedPrice,
         );
+      });
+    });
+
+    [
+      {
+        price: {
+          value: 4,
+          currency: "kr",
+          quantity: Quantity.parse("1", "2ml/1")!,
+        },
+        quantity: MixedQuantities.from(4, "ml"),
+        expectedPrice: { value: 8, currency: "kr" },
+      },
+      {
+        price: {
+          value: 5,
+          currency: "€",
+          quantity: Quantity.parse("1l", "200g/1l")!,
+        },
+        quantity: MixedQuantities.from(5, "kg"),
+        expectedPrice: { value: 125, currency: "€" },
+      },
+      {
+        price: {
+          value: 10,
+          currency: "$",
+          quantity: Quantity.parse("50cl", "1cl/10g")!,
+        },
+        quantity: MixedQuantities.parse("1l|1kg"),
+        expectedPrice: { value: 40, currency: "$" },
+      },
+    ].forEach(({ price, quantity, expectedPrice }) => {
+      it(`should return the total price for incompatible types with conversion rule. e.g. ${price.quantity} != ${quantity}`, () => {
+        expect(
+          getTotalPriceForQuantity(
+            price,
+            quantity,
+          ),
+        ).toEqual(expectedPrice);
+      });
+    });
+
+    [
+      {
+        priceQuantity: Quantity.from(4),
+        quantity: MixedQuantities.from(4, "ml"),
+      },
+      {
+        priceQuantity: Quantity.from(5, "ml"),
+        quantity: MixedQuantities.from(5, "kg"),
+      },
+      {
+        priceQuantity: Quantity.from(6, "mg"),
+        quantity: MixedQuantities.from(6),
+      },
+    ].forEach(({ priceQuantity, quantity }) => {
+      it(`should return "undefined" otherwise. e.g. ${priceQuantity} != ${quantity}`, () => {
+        expect(
+          getTotalPriceForQuantity(
+            { value: 4, currency: "kr", quantity: priceQuantity },
+            quantity,
+          ),
+        ).toBeUndefined();
       });
     });
   });

--- a/src/price.spec.ts
+++ b/src/price.spec.ts
@@ -1,5 +1,9 @@
-import { getTotalPriceForQuantity, parsePrice, serializeTotalPrice } from "./price";
-import { MixedQuantities } from "./quantities";
+import {
+  getTotalPriceForQuantity,
+  parsePrice,
+  serializeTotalPrice,
+} from "./price";
+import { MixedQuantities, Quantity } from "./quantities";
 
 const error = console.error;
 const warn = console.warn;
@@ -20,86 +24,151 @@ describe("price", () => {
       expect(() => parsePrice("Coucou !")).toThrow("Invalid price: Coucou !");
     });
 
-    [{
-      input: "4kr",
-      output: {
-        value: 4,
-        currency: "kr",
-        quantity: MixedQuantities.from(1),
+    [
+      {
+        input: "4kr",
+        conversions: undefined,
+        output: {
+          value: 4,
+          currency: "kr",
+          quantity: Quantity.from(1),
+        },
       },
-    }, {
-      input: "4€",
-      output: {
-        value: 4,
-        currency: "€",
-        quantity: MixedQuantities.from(1),
+      {
+        input: "4€",
+        conversions: "450g/1",
+        output: {
+          value: 4,
+          currency: "€",
+          quantity: Quantity.from(
+            1,
+            "",
+            new Map([
+              [
+                "mass",
+                new Map([["", [Quantity.from(450, "g"), Quantity.from(1)]]]),
+              ],
+            ]),
+          ),
+        },
       },
-    }, {
-      input: "4kr/kg",
-      output: {
-        value: 4,
-        currency: "kr",
-        quantity: MixedQuantities.from(1, "kg"),
+      {
+        input: "4kr/kg",
+        conversions: "100ml/150g",
+        output: {
+          value: 4,
+          currency: "kr",
+          quantity: Quantity.from(1, "kg", new Map([
+            ["volume", new Map([
+              ["mass", [Quantity.from(100, "ml"), Quantity.from(150, "g")]],
+            ])],
+          ])),
+        },
       },
-    }, {
-      input: "8kr/12",
-      output: {
-        value: 8,
-        currency: "kr",
-        quantity: MixedQuantities.from(12),
+      {
+        input: "8kr/12",
+        conversions: "10ml/50g\n10ml/1",
+        output: {
+          value: 8,
+          currency: "kr",
+          quantity: Quantity.from(12, "", new Map([
+            ["volume", new Map([
+              ["mass", [Quantity.from(10, "ml"), Quantity.from(50, "g")]],
+              ["", [Quantity.from(10, "ml"), Quantity.from(1)]],
+            ])],
+          ])),
+        },
       },
-    }, {
-      input: "16kr/250ml",
-      output: {
-        value: 16,
-        currency: "kr",
-        quantity: MixedQuantities.from(250, "ml"),
+      {
+        input: "16kr/250ml",
+        conversions: "83g/70ml\n50ml/2",
+        output: {
+          value: 16,
+          currency: "kr",
+          quantity: Quantity.from(250, "ml", new Map([
+            ["mass", new Map([
+              ["volume", [Quantity.from(83, "g"), Quantity.from(70, "ml")]],
+            ])],
+            ["volume", new Map([
+              ["", [Quantity.from(50, "ml"), Quantity.from(2)]],
+            ])],
+          ])),
+        },
       },
-    }].forEach(({ input, output }) => it(`should parse ${input}`, () => {
-      expect(parsePrice(input)).toEqual(output);
-    }));
+    ].forEach(({ input, conversions, output }) =>
+      it(`should parse ${input}`, () => {
+        expect(parsePrice(input, conversions)).toEqual(output);
+      }),
+    );
   });
 
   describe("getTotalPriceForQuantity", () => {
-    [{
-      priceQuantity: MixedQuantities.from(4),
-      quantity: MixedQuantities.from(4, "ml"),
-    }, {
-      priceQuantity: MixedQuantities.from(5, "ml"),
-      quantity: MixedQuantities.from(5, "kg"),
-    }, {
-      priceQuantity: MixedQuantities.from(6, "mg"),
-      quantity: MixedQuantities.from(6),
-    }].forEach(({ priceQuantity, quantity }) => {
+    [
+      {
+        priceQuantity: Quantity.from(4),
+        quantity: MixedQuantities.from(4, "ml"),
+      },
+      {
+        priceQuantity: Quantity.from(5, "ml"),
+        quantity: MixedQuantities.from(5, "kg"),
+      },
+      {
+        priceQuantity: Quantity.from(6, "mg"),
+        quantity: MixedQuantities.from(6),
+      },
+    ].forEach(({ priceQuantity, quantity }) => {
       it(`should return "undefined" if quantities are not of the same dimension. e.g. ${priceQuantity} != ${quantity}`, () => {
-        expect(getTotalPriceForQuantity({ value: 4, currency: "kr", quantity: priceQuantity }, quantity)).toBeUndefined();
+        expect(
+          getTotalPriceForQuantity(
+            { value: 4, currency: "kr", quantity: priceQuantity },
+            quantity,
+          ),
+        ).toBeUndefined();
       });
     });
 
-    [{
-      price: { value: 4, currency: "kr", quantity: MixedQuantities.from(5, "ml")},
-      quantity: MixedQuantities.from(10, "ml"),
-      expectedPrice: { value: 8, currency: "kr" },
-    }, {
-      price: { value: 5, currency: "€", quantity: MixedQuantities.from(3, "mg")} as const,
-      quantity: MixedQuantities.from(10, "mg"),
-      expectedPrice: { value: 16.67, currency: "€" },
-    }].forEach(({ price, quantity, expectedPrice }, index) => {
+    [
+      {
+        price: {
+          value: 4,
+          currency: "kr",
+          quantity: Quantity.from(5, "ml"),
+        },
+        quantity: MixedQuantities.from(10, "ml"),
+        expectedPrice: { value: 8, currency: "kr" },
+      },
+      {
+        price: {
+          value: 5,
+          currency: "€",
+          quantity: Quantity.from(3, "mg"),
+        } as const,
+        quantity: MixedQuantities.from(10, "mg"),
+        expectedPrice: { value: 16.67, currency: "€" },
+      },
+    ].forEach(({ price, quantity, expectedPrice }, index) => {
       it(`should return the total price otherwise. #${index}`, () => {
-        expect(getTotalPriceForQuantity(price, quantity)).toEqual(expectedPrice);
+        expect(getTotalPriceForQuantity(price, quantity)).toEqual(
+          expectedPrice,
+        );
       });
     });
   });
 
   describe("serializeTotalPrice", () => {
-    [{
-      input: { value: 5, currency: "€" },
-      output: "5€",
-    }, {
-      input: { value: 1 / 3, currency: "kr" },
-      output: "0.33kr",
-    }].forEach(({ input, output }) => it(`should serialize ${JSON.stringify(input)} to ${output}`, () => {
-      expect(serializeTotalPrice(input)).toBe(output);
-    }));
+    [
+      {
+        input: { value: 5, currency: "€" },
+        output: "5€",
+      },
+      {
+        input: { value: 1 / 3, currency: "kr" },
+        output: "0.33kr",
+      },
+    ].forEach(({ input, output }) =>
+      it(`should serialize ${JSON.stringify(input)} to ${output}`, () => {
+        expect(serializeTotalPrice(input)).toBe(output);
+      }),
+    );
   });
 });

--- a/src/price.ts
+++ b/src/price.ts
@@ -1,9 +1,9 @@
-import { MixedQuantities } from "./quantities";
+import { MixedQuantities, Quantity } from "./quantities";
 
 export type Price = {
   value: number;
   currency: string;
-  quantity: MixedQuantities;
+  quantity: Quantity;
 };
 
 export type TotalPrice = {
@@ -11,7 +11,7 @@ export type TotalPrice = {
   currency: string;
 };
 
-export function parsePrice(str: string): Price {
+export function parsePrice(str: string, conversions: string = ""): Price {
   const result = str.match(/^([0-9.]+)([^0-9\/]+)(\/(.*))?$/);
   if (result === null) {
     throw new Error(`Invalid price: ${str}`);
@@ -21,10 +21,10 @@ export function parsePrice(str: string): Price {
   const value = parseFloat(valueString);
 
   const quantity = quantityString
-    ? MixedQuantities.parse((/^[0-9]/).test(quantityString) ? quantityString : `1${quantityString}`)
-    : MixedQuantities.from(1);
+    ? Quantity.parse((/^[0-9]/).test(quantityString) ? quantityString : `1${quantityString}`, conversions)
+    : Quantity.parse("1", conversions);
 
-  if (typeof quantity === "string") {
+  if (typeof quantity === "undefined") {
     throw new Error(`Invalid quantity: ${quantityString}`);
   }
 
@@ -34,7 +34,7 @@ export function parsePrice(str: string): Price {
 export function getTotalPriceForQuantity(price: Price, quantity: MixedQuantities): TotalPrice | undefined {
   try {
     return {
-      value: Math.round(quantity.divide(price.quantity) * price.value * 100) / 100,
+      value: Math.round(quantity.divide(MixedQuantities.parse(price.quantity.toString())!) * price.value * 100) / 100,
       currency: price.currency,
     };
   } catch (err) {

--- a/src/price.ts
+++ b/src/price.ts
@@ -31,10 +31,15 @@ export function parsePrice(str: string, conversions: string = ""): Price {
   return { value, currency, quantity };
 }
 
-export function getTotalPriceForQuantity(price: Price, quantity: MixedQuantities): TotalPrice | undefined {
+export function getTotalPriceForQuantity(price: Price, mixedQuantities: MixedQuantities): TotalPrice | undefined {
   try {
+    const prices = mixedQuantities.quantities().map(quantity => {
+      const quantityWithConversion = new Quantity(quantity.q, price.quantity.conversions);
+      return quantityWithConversion.divide(price.quantity) * price.value;
+    });
+
     return {
-      value: Math.round(quantity.divide(MixedQuantities.parse(price.quantity.toString())!) * price.value * 100) / 100,
+      value: Math.round(prices.reduce((acc, item) => acc + item, 0) * 100) / 100,
       currency: price.currency,
     };
   } catch (err) {

--- a/src/quantities/index.ts
+++ b/src/quantities/index.ts
@@ -1,3 +1,4 @@
 export { Mass, MassUnit } from "./mass";
 export { Volume, VolumeUnit } from "./volume";
 export { MixedQuantities } from "./mixed-quantities";
+export { Quantity } from "./quantity";

--- a/src/quantities/mixed-quantities.ts
+++ b/src/quantities/mixed-quantities.ts
@@ -3,6 +3,7 @@ import { Mass } from "./mass";
 import { Volume } from "./volume";
 import { Length } from "./length";
 import { Area } from "./xarea";
+import { Quantity } from "./quantity";
 
 export class MixedQuantities implements PhysicalQuantity {
 
@@ -133,6 +134,19 @@ export class MixedQuantities implements PhysicalQuantity {
     return Object.keys(this.inventory)
       .filter((key) => this.inventory[key])
       .flatMap((key) => key === "unknown" ? Array.from(this.inventory.unknown!.keys()) : [key]);
+  }
+
+  quantities(): Quantity[] {
+    const known = [
+      this.inventory.volume && Quantity.parse(this.inventory.volume.toString()),
+      this.inventory.mass && Quantity.parse(this.inventory.mass.toString()),
+      this.inventory.length && Quantity.parse(this.inventory.length.toString()),
+      this.inventory.area && Quantity.parse(this.inventory.area.toString()),
+    ].filter(quantity => quantity !== undefined) as Quantity[];
+
+    return known.concat(this.inventory.unknown
+      ? Array.from(this.inventory.unknown.entries()).map(([unit, count]) => Quantity.from(count, unit))
+      : []);
   }
 
   toString(): string {

--- a/src/quantities/mixed-quantities.ts
+++ b/src/quantities/mixed-quantities.ts
@@ -59,7 +59,7 @@ export class MixedQuantities implements PhysicalQuantity {
     }
 
     const trimmedUnit = unit.trim();
-    if (trimmedUnit !== "") {
+    if (["", "p"].indexOf(trimmedUnit) < 0) {
       console.warn(`Unrecognized unit: ${trimmedUnit}`);
     }
 

--- a/src/quantities/quantity.spec.ts
+++ b/src/quantities/quantity.spec.ts
@@ -224,8 +224,18 @@ describe("quantities/quantity", () => {
     ].forEach(([type, quantity]) => {
       it(`should be able to parse a ${type} -> unknown conversion`, () => {
         fc.assert(
-          fc.property(quantity, fc.nat(), otherUnit(), (a, n, unit) => {
+          fc.property(quantity, fc.nat(), otherUnit().filter(unit => unit !== ""), (a, n, unit) => {
             const conversion = `${a.toString()}/${n} ${unit}`;
+            const [quantity1, quantity2] = Quantity.parseConversion(conversion);
+            expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
+              conversion,
+            );
+          }),
+        );
+
+        fc.assert(
+          fc.property(quantity, fc.nat(), (a, n) => {
+            const conversion = `${a.toString()}/${n}`;
             const [quantity1, quantity2] = Quantity.parseConversion(conversion);
             expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
               conversion,
@@ -236,8 +246,18 @@ describe("quantities/quantity", () => {
 
       it(`should be able to parse an unknown -> ${type} conversion`, () => {
         fc.assert(
-          fc.property(fc.nat(), otherUnit(), quantity, (n, unit, b) => {
+          fc.property(fc.nat(), otherUnit().filter(unit => unit !== ""), quantity, (n, unit, b) => {
             const conversion = `${n} ${unit}/${b.toString()}`;
+            const [quantity1, quantity2] = Quantity.parseConversion(conversion);
+            expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
+              conversion,
+            );
+          }),
+        );
+
+        fc.assert(
+          fc.property(fc.nat(), quantity, (n, b) => {
+            const conversion = `${n}/${b.toString()}`;
             const [quantity1, quantity2] = Quantity.parseConversion(conversion);
             expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
               conversion,

--- a/src/quantities/quantity.spec.ts
+++ b/src/quantities/quantity.spec.ts
@@ -1,0 +1,175 @@
+import * as fc from "fast-check"
+import { Quantity } from "./quantity";
+import { Volume } from "./volume";
+import { Mass } from "./mass";
+import { Length } from "./length";
+import { Area } from "./xarea";
+
+const warn = console.warn;
+beforeEach(() => {
+  global.console.warn = jest.fn();
+});
+
+afterEach(() => {
+  global.console.warn = warn;
+});
+
+describe("quantities/quantity", () => {
+  describe("from", () => {
+    it("should recognize a volume", () => {
+      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Volume.units()), (count, unit) => {
+        expect(Quantity.from(count, unit).q).toEqual({
+          type: "volume",
+          value: Volume.from(count, unit),
+        });
+      }));
+    });
+
+    it("should recognize a mass", () => {
+      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Mass.units()), (count, unit) => {
+        expect(Quantity.from(count, unit).q).toEqual({
+          type: "mass",
+          value: Mass.from(count, unit),
+        });
+      }));
+    });
+
+    it("should recognize a length", () => {
+      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Length.units()), (count, unit) => {
+        expect(Quantity.from(count, unit).q).toEqual({
+          type: "length",
+          value: Length.from(count, unit),
+        });
+      }));
+    });
+
+    it("should recognize an area", () => {
+      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Area.units()), (count, unit) => {
+        expect(Quantity.from(count, unit).q).toEqual({
+          type: "area",
+          value: Area.from(count, unit),
+        });
+      }));
+    });
+
+    it("should track anything else under its own unit", () => {
+      fc.assert(fc.property(fc.nat(), otherUnit(), (count, unit) => {
+        expect(Quantity.from(count, unit).q).toEqual({
+          type: "unknown",
+          unit,
+          count,
+        });
+      }));
+    });
+
+    it("should treat undefined as an empty unit", () => {
+      fc.assert(fc.property(fc.nat(), (count) => {
+        expect(Quantity.from(count, undefined).q).toEqual({
+          type: "unknown",
+          unit: "",
+          count,
+        });
+      }));
+    });
+  });
+
+  describe("parse", () => {
+    it("should parse numbers", () => {
+      fc.assert(fc.property(fc.nat(), (value) => {
+        expect(Quantity.parse(value)?.q).toEqual({
+          type: "unknown",
+          unit: "",
+          count: value,
+        });
+      }));
+    });
+
+    it("should be able to parse any serialization of a volume", () => {
+      fc.assert(fc.property(vol(), (volume) => {
+        /*
+         * Repeating the operation twice mitigates failures caused by rounded values.
+         * Example given:
+         * 1. 1001 milliliters serialize to 1l
+         * 2. 1l gets parsed to 1000 milliliters
+         * 3. Which serializes to 1l again
+         */
+        const roundedValue = Quantity.parse(volume.toString());
+        expect(roundedValue).toBeDefined();
+        expect(roundedValue?.q.type).toEqual("volume");
+
+        const serializedValue = roundedValue?.toString();
+        expect(serializedValue).toEqual(volume.toString());
+        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+      }));
+    });
+
+    it("should be able to parse any serialization of a mass", () => {
+      fc.assert(fc.property(mass(), (mass) => {
+        const roundedValue = Quantity.parse(mass.toString());
+        expect(roundedValue).toBeDefined();
+        expect(roundedValue?.q.type).toEqual("mass");
+
+        const serializedValue = roundedValue?.toString();
+        expect(serializedValue).toEqual(mass.toString());
+        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+      }));
+    });
+
+    it("should be able to parse any serialization of a length", () => {
+      fc.assert(fc.property(len(), (length) => {
+        const roundedValue = Quantity.parse(length.toString());
+        expect(roundedValue).toBeDefined();
+        expect(roundedValue?.q.type).toEqual("length");
+
+        const serializedValue = roundedValue?.toString();
+        expect(serializedValue).toEqual(length.toString());
+        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+      }));
+    });
+
+    it("should be able to parse any serialization of an area", () => {
+      fc.assert(fc.property(area(), (area) => {
+        const roundedValue = Quantity.parse(area.toString());
+        expect(roundedValue).toBeDefined();
+        expect(roundedValue?.q.type).toEqual("area");
+
+        const serializedValue = roundedValue?.toString();
+        expect(serializedValue).toEqual(area.toString());
+        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+      }));
+    });
+
+    it("should be able to parse a quantity of an unknown unit", () => {
+      fc.assert(fc.property(otherUnit(), fc.nat(), (unit, count) => {
+        const quantity = Quantity.parse(`${count} ${unit}`);
+        expect(quantity).toBeDefined();
+        expect(quantity?.q.type).toEqual("unknown");
+        expect((quantity as any).q.count).toEqual(count);
+        expect((quantity as any).q.unit).toEqual(unit);
+      }));
+    });
+  });
+});
+
+function otherUnit() {
+  return fc.string()
+    .map(str => str.replace(/ /g, ""))
+    .filter(str => ([...Volume.units(), ...Mass.units(), ...Length.units()] as readonly string[]).indexOf(str) === -1)
+    .filter(str => str.indexOf("|") === -1);
+}
+
+function vol(constraints?: fc.IntegerConstraints): fc.Arbitrary<Volume> {
+  return fc.integer({ min: 0, ...constraints }).map(milliliters => new Volume(milliliters));
+}
+
+function mass(constraints?: fc.IntegerConstraints): fc.Arbitrary<Mass> {
+  return fc.integer({ min: 0, ...constraints }).map(milligrams => new Mass(milligrams));
+}
+
+function len(constraints?: fc.IntegerConstraints): fc.Arbitrary<Length> {
+  return fc.integer({ min: 0, ...constraints }).map(millimeters => new Length(millimeters));
+}
+
+function area(constraints?: fc.IntegerConstraints): fc.Arbitrary<Area> {
+  return fc.integer({ min: 0, ...constraints }).map(squaredMillimeters => new Area(squaredMillimeters));
+}

--- a/src/quantities/quantity.spec.ts
+++ b/src/quantities/quantity.spec.ts
@@ -1,4 +1,4 @@
-import * as fc from "fast-check"
+import * as fc from "fast-check";
 import { Quantity } from "./quantity";
 import { Volume } from "./volume";
 import { Mass } from "./mass";
@@ -17,159 +17,276 @@ afterEach(() => {
 describe("quantities/quantity", () => {
   describe("from", () => {
     it("should recognize a volume", () => {
-      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Volume.units()), (count, unit) => {
-        expect(Quantity.from(count, unit).q).toEqual({
-          type: "volume",
-          value: Volume.from(count, unit),
-        });
-      }));
+      fc.assert(
+        fc.property(
+          fc.nat(),
+          fc.constantFrom(...Volume.units()),
+          (count, unit) => {
+            expect(Quantity.from(count, unit).q).toEqual({
+              type: "volume",
+              value: Volume.from(count, unit),
+            });
+          },
+        ),
+      );
     });
 
     it("should recognize a mass", () => {
-      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Mass.units()), (count, unit) => {
-        expect(Quantity.from(count, unit).q).toEqual({
-          type: "mass",
-          value: Mass.from(count, unit),
-        });
-      }));
+      fc.assert(
+        fc.property(
+          fc.nat(),
+          fc.constantFrom(...Mass.units()),
+          (count, unit) => {
+            expect(Quantity.from(count, unit).q).toEqual({
+              type: "mass",
+              value: Mass.from(count, unit),
+            });
+          },
+        ),
+      );
     });
 
     it("should recognize a length", () => {
-      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Length.units()), (count, unit) => {
-        expect(Quantity.from(count, unit).q).toEqual({
-          type: "length",
-          value: Length.from(count, unit),
-        });
-      }));
+      fc.assert(
+        fc.property(
+          fc.nat(),
+          fc.constantFrom(...Length.units()),
+          (count, unit) => {
+            expect(Quantity.from(count, unit).q).toEqual({
+              type: "length",
+              value: Length.from(count, unit),
+            });
+          },
+        ),
+      );
     });
 
     it("should recognize an area", () => {
-      fc.assert(fc.property(fc.nat(), fc.constantFrom(...Area.units()), (count, unit) => {
-        expect(Quantity.from(count, unit).q).toEqual({
-          type: "area",
-          value: Area.from(count, unit),
-        });
-      }));
+      fc.assert(
+        fc.property(
+          fc.nat(),
+          fc.constantFrom(...Area.units()),
+          (count, unit) => {
+            expect(Quantity.from(count, unit).q).toEqual({
+              type: "area",
+              value: Area.from(count, unit),
+            });
+          },
+        ),
+      );
     });
 
     it("should track anything else under its own unit", () => {
-      fc.assert(fc.property(fc.nat(), otherUnit(), (count, unit) => {
-        expect(Quantity.from(count, unit).q).toEqual({
-          type: "unknown",
-          unit,
-          count,
-        });
-      }));
+      fc.assert(
+        fc.property(fc.nat(), otherUnit(), (count, unit) => {
+          expect(Quantity.from(count, unit).q).toEqual({
+            type: "unknown",
+            unit,
+            count,
+          });
+        }),
+      );
     });
 
     it("should treat undefined as an empty unit", () => {
-      fc.assert(fc.property(fc.nat(), (count) => {
-        expect(Quantity.from(count, undefined).q).toEqual({
-          type: "unknown",
-          unit: "",
-          count,
-        });
-      }));
+      fc.assert(
+        fc.property(fc.nat(), (count) => {
+          expect(Quantity.from(count, undefined).q).toEqual({
+            type: "unknown",
+            unit: "",
+            count,
+          });
+        }),
+      );
     });
   });
 
   describe("parse", () => {
     it("should parse numbers", () => {
-      fc.assert(fc.property(fc.nat(), (value) => {
-        expect(Quantity.parse(value)?.q).toEqual({
-          type: "unknown",
-          unit: "",
-          count: value,
-        });
-      }));
+      fc.assert(
+        fc.property(fc.nat(), (value) => {
+          expect(Quantity.parse(value)?.q).toEqual({
+            type: "unknown",
+            unit: "",
+            count: value,
+          });
+        }),
+      );
     });
 
     it("should be able to parse any serialization of a volume", () => {
-      fc.assert(fc.property(vol(), (volume) => {
-        /*
-         * Repeating the operation twice mitigates failures caused by rounded values.
-         * Example given:
-         * 1. 1001 milliliters serialize to 1l
-         * 2. 1l gets parsed to 1000 milliliters
-         * 3. Which serializes to 1l again
-         */
-        const roundedValue = Quantity.parse(volume.toString());
-        expect(roundedValue).toBeDefined();
-        expect(roundedValue?.q.type).toEqual("volume");
+      fc.assert(
+        fc.property(vol(), (volume) => {
+          /*
+           * Repeating the operation twice mitigates failures caused by rounded values.
+           * Example given:
+           * 1. 1001 milliliters serialize to 1l
+           * 2. 1l gets parsed to 1000 milliliters
+           * 3. Which serializes to 1l again
+           */
+          const roundedValue = Quantity.parse(volume.toString());
+          expect(roundedValue).toBeDefined();
+          expect(roundedValue?.q.type).toEqual("volume");
 
-        const serializedValue = roundedValue?.toString();
-        expect(serializedValue).toEqual(volume.toString());
-        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
-      }));
+          const serializedValue = roundedValue?.toString();
+          expect(serializedValue).toEqual(volume.toString());
+          expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+        }),
+      );
     });
 
     it("should be able to parse any serialization of a mass", () => {
-      fc.assert(fc.property(mass(), (mass) => {
-        const roundedValue = Quantity.parse(mass.toString());
-        expect(roundedValue).toBeDefined();
-        expect(roundedValue?.q.type).toEqual("mass");
+      fc.assert(
+        fc.property(mass(), (mass) => {
+          const roundedValue = Quantity.parse(mass.toString());
+          expect(roundedValue).toBeDefined();
+          expect(roundedValue?.q.type).toEqual("mass");
 
-        const serializedValue = roundedValue?.toString();
-        expect(serializedValue).toEqual(mass.toString());
-        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
-      }));
+          const serializedValue = roundedValue?.toString();
+          expect(serializedValue).toEqual(mass.toString());
+          expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+        }),
+      );
     });
 
     it("should be able to parse any serialization of a length", () => {
-      fc.assert(fc.property(len(), (length) => {
-        const roundedValue = Quantity.parse(length.toString());
-        expect(roundedValue).toBeDefined();
-        expect(roundedValue?.q.type).toEqual("length");
+      fc.assert(
+        fc.property(len(), (length) => {
+          const roundedValue = Quantity.parse(length.toString());
+          expect(roundedValue).toBeDefined();
+          expect(roundedValue?.q.type).toEqual("length");
 
-        const serializedValue = roundedValue?.toString();
-        expect(serializedValue).toEqual(length.toString());
-        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
-      }));
+          const serializedValue = roundedValue?.toString();
+          expect(serializedValue).toEqual(length.toString());
+          expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+        }),
+      );
     });
 
     it("should be able to parse any serialization of an area", () => {
-      fc.assert(fc.property(area(), (area) => {
-        const roundedValue = Quantity.parse(area.toString());
-        expect(roundedValue).toBeDefined();
-        expect(roundedValue?.q.type).toEqual("area");
+      fc.assert(
+        fc.property(area(), (area) => {
+          const roundedValue = Quantity.parse(area.toString());
+          expect(roundedValue).toBeDefined();
+          expect(roundedValue?.q.type).toEqual("area");
 
-        const serializedValue = roundedValue?.toString();
-        expect(serializedValue).toEqual(area.toString());
-        expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
-      }));
+          const serializedValue = roundedValue?.toString();
+          expect(serializedValue).toEqual(area.toString());
+          expect(Quantity.parse(serializedValue)).toEqual(roundedValue);
+        }),
+      );
     });
 
     it("should be able to parse a quantity of an unknown unit", () => {
-      fc.assert(fc.property(otherUnit(), fc.nat(), (unit, count) => {
-        const quantity = Quantity.parse(`${count} ${unit}`);
-        expect(quantity).toBeDefined();
-        expect(quantity?.q.type).toEqual("unknown");
-        expect((quantity as any).q.count).toEqual(count);
-        expect((quantity as any).q.unit).toEqual(unit);
-      }));
+      fc.assert(
+        fc.property(otherUnit(), fc.nat(), (unit, count) => {
+          const quantity = Quantity.parse(`${count} ${unit}`);
+          expect(quantity).toBeDefined();
+          expect(quantity?.q.type).toEqual("unknown");
+          expect((quantity as any).q.count).toEqual(count);
+          expect((quantity as any).q.unit).toEqual(unit);
+        }),
+      );
+    });
+
+    [
+      ["volume", vol(), "mass", mass()] as const,
+      ["volume", vol(), "length", len()] as const,
+      ["volume", vol(), "area", area()] as const,
+      ["mass", mass(), "volume", vol()] as const,
+      ["mass", mass(), "length", len()] as const,
+      ["mass", mass(), "area", area()] as const,
+      ["length", len(), "volume", vol()] as const,
+      ["length", len(), "mass", mass()] as const,
+      ["length", len(), "area", area()] as const,
+      ["area", area(), "volume", vol()] as const,
+      ["area", area(), "mass", mass()] as const,
+      ["area", area(), "length", len()] as const,
+    ].forEach(([type1, quantity1, type2, quantity2]) => {
+      it(`should be able to parse a ${type1} -> ${type2} conversion`, () => {
+        fc.assert(
+          fc.property(quantity1, quantity2, (a, b) => {
+            const conversion = `${a.toString()}/${b.toString()}`;
+            const [quantity1, quantity2] = Quantity.parseConversion(conversion);
+            expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
+              conversion,
+            );
+          }),
+        );
+      });
+    });
+
+    [
+      ["volume", vol()] as const,
+      ["mass", mass()] as const,
+      ["length", len()] as const,
+      ["area", area()] as const,
+    ].forEach(([type, quantity]) => {
+      it(`should be able to parse a ${type} -> unknown conversion`, () => {
+        fc.assert(
+          fc.property(quantity, fc.nat(), otherUnit(), (a, n, unit) => {
+            const conversion = `${a.toString()}/${n} ${unit}`;
+            const [quantity1, quantity2] = Quantity.parseConversion(conversion);
+            expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
+              conversion,
+            );
+          }),
+        );
+      });
+
+      it(`should be able to parse an unknown -> ${type} conversion`, () => {
+        fc.assert(
+          fc.property(fc.nat(), otherUnit(), quantity, (n, unit, b) => {
+            const conversion = `${n} ${unit}/${b.toString()}`;
+            const [quantity1, quantity2] = Quantity.parseConversion(conversion);
+            expect(`${quantity1.toString()}/${quantity2.toString()}`).toEqual(
+              conversion,
+            );
+          }),
+        );
+      });
     });
   });
 });
 
 function otherUnit() {
-  return fc.string()
-    .map(str => str.replace(/ /g, ""))
-    .filter(str => ([...Volume.units(), ...Mass.units(), ...Length.units()] as readonly string[]).indexOf(str) === -1)
-    .filter(str => str.indexOf("|") === -1);
+  return fc
+    .string()
+    .map((str) => str.replace(/ /g, ""))
+    .filter(
+      (str) =>
+        (
+          [
+            ...Volume.units(),
+            ...Mass.units(),
+            ...Length.units(),
+          ] as readonly string[]
+        ).indexOf(str) === -1,
+    )
+    .filter((str) => str.indexOf("|") === -1)
+    .filter((str) => str.indexOf("/") === -1);
 }
 
 function vol(constraints?: fc.IntegerConstraints): fc.Arbitrary<Volume> {
-  return fc.integer({ min: 0, ...constraints }).map(milliliters => new Volume(milliliters));
+  return fc
+    .integer({ min: 0, ...constraints })
+    .map((milliliters) => new Volume(milliliters));
 }
 
 function mass(constraints?: fc.IntegerConstraints): fc.Arbitrary<Mass> {
-  return fc.integer({ min: 0, ...constraints }).map(milligrams => new Mass(milligrams));
+  return fc
+    .integer({ min: 0, ...constraints })
+    .map((milligrams) => new Mass(milligrams));
 }
 
 function len(constraints?: fc.IntegerConstraints): fc.Arbitrary<Length> {
-  return fc.integer({ min: 0, ...constraints }).map(millimeters => new Length(millimeters));
+  return fc
+    .integer({ min: 0, ...constraints })
+    .map((millimeters) => new Length(millimeters));
 }
 
 function area(constraints?: fc.IntegerConstraints): fc.Arbitrary<Area> {
-  return fc.integer({ min: 0, ...constraints }).map(squaredMillimeters => new Area(squaredMillimeters));
+  return fc
+    .integer({ min: 0, ...constraints })
+    .map((squaredMillimeters) => new Area(squaredMillimeters));
 }

--- a/src/quantities/quantity.ts
+++ b/src/quantities/quantity.ts
@@ -1,0 +1,213 @@
+import { Mass } from "./mass";
+import { Volume } from "./volume";
+import { Length } from "./length";
+import { Area } from "./xarea";
+import { PhysicalQuantity } from "./types";
+
+export class Quantity implements PhysicalQuantity {
+
+  q: {
+    type: "volume";
+    value: Volume;
+  } | {
+    type: "mass";
+    value: Mass;
+  } | {
+    type: "length";
+    value: Length;
+  } | {
+    type: "area";
+    value: Area;
+  } | {
+    type: "unknown";
+    unit: string;
+    count: number;
+  };
+
+  constructor(q: typeof Quantity.prototype.q) {
+    this.q = q;
+  }
+
+  static parse(value: number | string = ""): Quantity | undefined {
+    if (typeof value === "number") {
+      return Quantity.from(value);
+    }
+
+    const result = value.match(/^([0-9.]+)\s*(\S*)$/);
+    if (!result) return undefined;
+
+    return Quantity.from(parseFloat(result[1]), result[2]);
+  }
+
+  static from(count: number, unit: string = ""): Quantity {
+    if (Volume.supportsUnit(unit)) {
+      return new Quantity({
+        type: "volume",
+        value: Volume.from(count, unit)
+      });
+    }
+
+    if (Mass.supportsUnit(unit)) {
+      return new Quantity({
+        type: "mass",
+        value: Mass.from(count, unit)
+      });
+    }
+
+    if (Length.supportsUnit(unit)) {
+      return new Quantity({
+        type: "length",
+        value: Length.from(count, unit)
+      });
+    }
+
+    if (Area.supportsUnit(unit)) {
+      return new Quantity({
+        type: "area",
+        value: Area.from(count, unit)
+      });
+    }
+
+    const trimmedUnit = unit.trim();
+    if (["", "p"].indexOf(trimmedUnit) < 0) {
+      console.warn(`Unrecognized unit: ${trimmedUnit}`);
+    }
+
+    return new Quantity({
+      type: "unknown",
+      unit: trimmedUnit,
+      count,
+    });
+  }
+
+  add(quantity?: Quantity): Quantity {
+    if (!quantity) return this;
+
+    switch (this.q.type) {
+      case "volume":
+        if (quantity.q.type === "volume") {
+          return new Quantity({
+            type: "volume",
+            value: this.q.value.add(quantity.q.value),
+          });
+        }
+        break;
+      case "mass":
+        if (quantity.q.type === "mass") {
+          return new Quantity({
+            type: "mass",
+            value: this.q.value.add(quantity.q.value),
+          });
+        }
+        break;
+      case "length":
+        if (quantity.q.type === "length") {
+          return new Quantity({
+            type: "length",
+            value: this.q.value.add(quantity.q.value),
+          });
+        }
+        break;
+      case "area":
+        if (quantity.q.type === "area") {
+          return new Quantity({
+            type: "area",
+            value: this.q.value.add(quantity.q.value),
+          });
+        }
+        break;
+      case "unknown":
+        if (quantity.q.type === "unknown") {
+          if (this.q.unit !== quantity.q.unit) {
+            throw new Error(`Incompatible units: ${this.q.unit} vs. ${quantity.q.unit}`);
+          }
+
+          return new Quantity({
+            type: "unknown",
+            unit: this.q.unit,
+            count: this.q.count + quantity.q.count,
+          });
+        }
+    }
+
+    throw new Error(`Incompatible types: ${this.q.type} vs. ${quantity.q.type}`);
+  }
+
+  multiply(factor: number): Quantity {
+    switch (this.q.type) {
+      case "volume":
+        return new Quantity({
+          type: this.q.type,
+          value: this.q.value.multiply(factor),
+        });
+      case "mass":
+        return new Quantity({
+          type: this.q.type,
+          value: this.q.value.multiply(factor),
+        });
+      case "length":
+        return new Quantity({
+          type: this.q.type,
+          value: this.q.value.multiply(factor),
+        });
+      case "area":
+        return new Quantity({
+          type: this.q.type,
+          value: this.q.value.multiply(factor),
+        });
+      case "unknown":
+        return new Quantity({
+          type: this.q.type,
+          unit: this.q.unit,
+          count: this.q.count * factor,
+        });
+    }
+  }
+
+  divide(quantity: Quantity): number {
+    switch (this.q.type) {
+      case "volume":
+        if (quantity.q.type === "volume") {
+          return this.q.value.divide(quantity.q.value);
+        }
+        break;
+      case "mass":
+        if (quantity.q.type === "mass") {
+          return this.q.value.divide(quantity.q.value);
+        }
+        break;
+      case "length":
+        if (quantity.q.type === "length") {
+          return this.q.value.divide(quantity.q.value);
+        }
+        break;
+      case "area":
+        if (quantity.q.type === "area") {
+          return this.q.value.divide(quantity.q.value);
+        }
+        break;
+      case "unknown":
+        if (quantity.q.type === "unknown") {
+          if (this.q.unit !== quantity.q.unit) {
+            throw new Error(`Incompatible units: ${this.q.unit} vs. ${quantity.q.unit}`);
+          }
+
+          return this.q.count / quantity.q.count;
+        }
+    }
+
+    throw new Error(`Incompatible types: ${this.q.type} vs. ${quantity.q.type}`);
+  }
+
+  toString(): string {
+    switch (this.q.type) {
+      case "volume":
+      case "mass":
+      case "length":
+      case "area":
+        return this.q.value.toString();
+      case "unknown":
+        return `${this.q.count} ${this.q.unit}`;
+    }
+  }
+}

--- a/src/quantities/quantity.ts
+++ b/src/quantities/quantity.ts
@@ -308,7 +308,7 @@ export class Quantity implements PhysicalQuantity {
       case "area":
         return this.q.value.toString();
       case "unknown":
-        return `${this.q.count} ${this.q.unit}`;
+        return this.q.unit === "" ? this.q.count.toString() : `${this.q.count} ${this.q.unit}`;
     }
   }
 }

--- a/src/quantities/quantity.ts
+++ b/src/quantities/quantity.ts
@@ -260,41 +260,43 @@ export class Quantity implements PhysicalQuantity {
   }
 
   divide(quantity: Quantity): number {
+    const convertedQuantity = quantity.tryConvertTo(this);
+
     switch (this.q.type) {
       case "volume":
-        if (quantity.q.type === "volume") {
-          return this.q.value.divide(quantity.q.value);
+        if (convertedQuantity.q.type === "volume") {
+          return this.q.value.divide(convertedQuantity.q.value);
         }
         break;
       case "mass":
-        if (quantity.q.type === "mass") {
-          return this.q.value.divide(quantity.q.value);
+        if (convertedQuantity.q.type === "mass") {
+          return this.q.value.divide(convertedQuantity.q.value);
         }
         break;
       case "length":
-        if (quantity.q.type === "length") {
-          return this.q.value.divide(quantity.q.value);
+        if (convertedQuantity.q.type === "length") {
+          return this.q.value.divide(convertedQuantity.q.value);
         }
         break;
       case "area":
-        if (quantity.q.type === "area") {
-          return this.q.value.divide(quantity.q.value);
+        if (convertedQuantity.q.type === "area") {
+          return this.q.value.divide(convertedQuantity.q.value);
         }
         break;
       case "unknown":
-        if (quantity.q.type === "unknown") {
-          if (this.q.unit !== quantity.q.unit) {
+        if (convertedQuantity.q.type === "unknown") {
+          if (this.q.unit !== convertedQuantity.q.unit) {
             throw new Error(
-              `Incompatible units: ${this.q.unit} vs. ${quantity.q.unit}`,
+              `Incompatible units: ${this.q.unit} vs. ${convertedQuantity.q.unit}`,
             );
           }
 
-          return this.q.count / quantity.q.count;
+          return this.q.count / convertedQuantity.q.count;
         }
     }
 
     throw new Error(
-      `Incompatible types: ${this.q.type} vs. ${quantity.q.type}`,
+      `Incompatible types: ${this.q.type} vs. ${convertedQuantity.q.type}`,
     );
   }
 

--- a/src/recipe.spec.ts
+++ b/src/recipe.spec.ts
@@ -1,3 +1,4 @@
+import { MixedQuantities } from "./quantities";
 import { formatRecipes, Recipe, resizeRecipe, sortRecipes } from "./recipe";
 
 const RECIPE: Recipe = {
@@ -5,90 +6,52 @@ const RECIPE: Recipe = {
   people: "6p",
   ingredients: [{
     name: "Cheese",
-    quantity: "300g",
+    quantity: MixedQuantities.parse("300g"),
   }, {
     name: "Crème Fraîche",
-    quantity: "2 c-à-s",
+    quantity: MixedQuantities.parse("2 c-à-s"),
   }, {
     name: "Onions",
-    quantity: 1,
+    quantity: MixedQuantities.parse(1),
   }],
 };
 
 describe("recipe", () => {
   describe("resizeRecipe", () => {
     it("should not change the recipe if the number of people is the same", () => {
-      expect(resizeRecipe(RECIPE, RECIPE.people)).toStrictEqual(RECIPE);
+      expect(resizeRecipe(RECIPE, RECIPE.people)).toEqual(RECIPE);
     });
 
     it("should adjust the quantities correctly when multiplying the number of people by 2", () => {
-      expect(resizeRecipe(RECIPE, "12p")).toStrictEqual({
+      expect(resizeRecipe(RECIPE, "12p")).toEqual({
         name: "Recipe 1",
         people: "12p",
         ingredients: [{
           name: "Cheese",
-          quantity: "600g",
+          quantity: MixedQuantities.parse("600g"),
         }, {
           name: "Crème Fraîche",
-          quantity: "4 c-à-s",
+          quantity: MixedQuantities.parse("4 c-à-s"),
         }, {
           name: "Onions",
-          quantity: 2,
+          quantity: MixedQuantities.parse(2),
         }],
       });
     });
 
     it("should adjust the quantities correctly when dividing the number of people by 2", () => {
-      expect(resizeRecipe(RECIPE, "3p")).toStrictEqual({
+      expect(resizeRecipe(RECIPE, "3p")).toEqual({
         name: "Recipe 1",
         people: "3p",
         ingredients: [{
           name: "Cheese",
-          quantity: "150g",
+          quantity: MixedQuantities.parse("150g"),
         }, {
           name: "Crème Fraîche",
-          quantity: "1 c-à-s",
+          quantity: MixedQuantities.parse("1 c-à-s"),
         }, {
           name: "Onions",
-          quantity: 0.5,
-        }],
-      });
-    });
-
-    it("should round string quantity values with a precision of two digits after the decimal point", () => {
-      expect(resizeRecipe(RECIPE, "2p")).toStrictEqual({
-        name: "Recipe 1",
-        people: "2p",
-        ingredients: [{
-          name: "Cheese",
-          quantity: "100g",
-        }, {
-          name: "Crème Fraîche",
-          quantity: "0.67 c-à-s",
-        }, {
-          name: "Onions",
-          quantity: 1 / 3,
-        }],
-      });
-    });
-
-    it("should handle decimal values as an input too", () => {
-      const recipe = { ...RECIPE, ingredients: RECIPE.ingredients.concat([{ name: "Milk", quantity: "0.5 dl" }]) };
-      expect(resizeRecipe(recipe, "6p")).toStrictEqual({
-        name: "Recipe 1",
-        people: "6p",
-        ingredients: [{
-          name: "Cheese",
-          quantity: "300g",
-        }, {
-          name: "Crème Fraîche",
-          quantity: "2 c-à-s",
-        }, {
-          name: "Onions",
-          quantity: 1,
-        }, {
-          name: "Milk",
-          quantity: "0.5 dl",
+          quantity: MixedQuantities.parse(0.5),
         }],
       });
     });
@@ -99,25 +62,25 @@ describe("recipe", () => {
       const range = createRangeFromValues([
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
+        ["", "Crème Fraîche", "3cl"],
         ["", "Onions", 1],
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
       ]);
 
       sortRecipes(range);
 
-      expect(range.getValues()).toStrictEqual([
+      expect(range.getValues()).toEqual([
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
       ]);
     });
 
@@ -126,24 +89,24 @@ describe("recipe", () => {
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
       ]);
 
       sortRecipes(range);
 
-      expect(range.getValues()).toStrictEqual([
+      expect(range.getValues()).toEqual([
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
       ]);
     });
 
@@ -152,11 +115,11 @@ describe("recipe", () => {
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
         ["", "", ""],
         ["", "", ""],
         ["", "", ""],
@@ -164,15 +127,15 @@ describe("recipe", () => {
 
       sortRecipes(range);
 
-      expect(range.getValues()).toStrictEqual([
+      expect(range.getValues()).toEqual([
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
         ["", "", ""],
         ["", "", ""],
         ["", "", ""],
@@ -186,11 +149,11 @@ describe("recipe", () => {
         ["Recipe 2", "", "2p"],
         ["", "Salad", ""],
         ["", "Bacon", "100g"],
-        ["", "Tomatoes", 4],
+        ["", "Tomatoes", "4"],
         ["Recipe 1", "", "6p"],
         ["", "Cheese", "300g"],
-        ["", "Crème Fraîche", "2 c-à-s"],
-        ["", "Onions", 1],
+        ["", "Crème Fraîche", "3cl"],
+        ["", "Onions", "1"],
         ["", "", ""],
         ["", "", ""],
         ["", "", ""],

--- a/src/recipe.spec.ts
+++ b/src/recipe.spec.ts
@@ -1,4 +1,4 @@
-import { MixedQuantities } from "./quantities";
+import { Quantity } from "./quantities";
 import { formatRecipes, Recipe, resizeRecipe, sortRecipes } from "./recipe";
 
 const RECIPE: Recipe = {
@@ -6,13 +6,13 @@ const RECIPE: Recipe = {
   people: "6p",
   ingredients: [{
     name: "Cheese",
-    quantity: MixedQuantities.parse("300g"),
+    quantity: Quantity.parse("300g"),
   }, {
     name: "Crème Fraîche",
-    quantity: MixedQuantities.parse("2 c-à-s"),
+    quantity: Quantity.parse("2 c-à-s"),
   }, {
     name: "Onions",
-    quantity: MixedQuantities.parse(1),
+    quantity: Quantity.parse(1),
   }],
 };
 
@@ -28,13 +28,13 @@ describe("recipe", () => {
         people: "12p",
         ingredients: [{
           name: "Cheese",
-          quantity: MixedQuantities.parse("600g"),
+          quantity: Quantity.parse("600g"),
         }, {
           name: "Crème Fraîche",
-          quantity: MixedQuantities.parse("4 c-à-s"),
+          quantity: Quantity.parse("4 c-à-s"),
         }, {
           name: "Onions",
-          quantity: MixedQuantities.parse(2),
+          quantity: Quantity.parse(2),
         }],
       });
     });
@@ -45,13 +45,13 @@ describe("recipe", () => {
         people: "3p",
         ingredients: [{
           name: "Cheese",
-          quantity: MixedQuantities.parse("150g"),
+          quantity: Quantity.parse("150g"),
         }, {
           name: "Crème Fraîche",
-          quantity: MixedQuantities.parse("1 c-à-s"),
+          quantity: Quantity.parse("1 c-à-s"),
         }, {
           name: "Onions",
-          quantity: MixedQuantities.parse(0.5),
+          quantity: Quantity.parse(0.5),
         }],
       });
     });

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -93,3 +93,17 @@ export function formatRecipes(range: GoogleAppsScript.Spreadsheet.Range) {
   const fontSizes = values.map(row => row.map(_ => row[0] ? 16 : 10));
   range.setFontSizes(fontSizes);
 }
+
+export function listIngredientsWithMultipleDimensions(recipes: Recipe[]): Ingredient[] {
+  return Object.values(recipes
+    .flatMap(recipe => recipe.ingredients)
+    .reduce((ingredientsByName, ingredient) => ({
+      ...ingredientsByName,
+      [ingredient.name]: {
+        ...ingredient,
+        quantity: ingredientsByName[ingredient.name]
+          ? ingredientsByName[ingredient.name].quantity.add(ingredient.quantity)
+          : ingredient.quantity,
+      },
+    }), {} as Record<string, Ingredient>)).filter(ingredient => ingredient.quantity.dimensions().length > 1);
+}

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -1,4 +1,5 @@
 import { RECIPE_SHEET_NAME, RECIPE_SHEET_RANGE } from "./init";
+import { MixedQuantities } from "./quantities";
 
 export type Recipe = {
   name: string;
@@ -8,10 +9,8 @@ export type Recipe = {
 
 export type Ingredient = {
   name: string;
-  quantity: Quantity;
+  quantity: MixedQuantities;
 };
-
-export type Quantity = number | `${number} ${string}` | `${number}${string}` | "";
 
 export function sortAndFormatRecipes() {
   const range = getRange();
@@ -52,7 +51,7 @@ function readRecipes(range: GoogleAppsScript.Spreadsheet.Range): Recipe[] {
     } else {
       recipes[recipes.length - 1].ingredients.push({
         name: row[1],
-        quantity: row[2],
+        quantity: MixedQuantities.parse(row[2]),
       });
     }
   }
@@ -63,7 +62,7 @@ function readRecipes(range: GoogleAppsScript.Spreadsheet.Range): Recipe[] {
 function writeRecipes(range: GoogleAppsScript.Spreadsheet.Range, recipes: Recipe[]) {
   const values = recipes.flatMap(recipe => ([
     [recipe.name, '', recipe.people],
-    ...recipe.ingredients.map(ingredient => (['', ingredient.name, ingredient.quantity]))
+    ...recipe.ingredients.map(ingredient => (['', ingredient.name, ingredient.quantity.toString()]))
   ]));
 
   const blank = new Array(range.getNumRows() - values.length).fill(['', '', '']);
@@ -82,28 +81,11 @@ export function resizeRecipe(recipe: Recipe, people: `${number}p`): Recipe {
   return {
     ...recipe,
     people,
-    ingredients: recipe.ingredients.map(ingredient => resizeIngredient(ingredient, ratio)),
+    ingredients: recipe.ingredients.map(ingredient => ({
+      ...ingredient,
+      quantity: ingredient.quantity.multiply(ratio),
+    })),
   };
-}
-
-function resizeIngredient(ingredient: Ingredient, ratio: number): Ingredient {
-  if (typeof ingredient.quantity === "number") {
-    return {
-      ...ingredient,
-      quantity: ingredient.quantity * ratio,
-    };
-  }
-
-  if (typeof ingredient.quantity === "string") {
-    return {
-      ...ingredient,
-      quantity: ingredient.quantity.replace(/^([0-9,.]+)/, (_, num) => {
-        return (Math.round(parseFloat(num) * ratio * 100) / 100).toString();
-      }) as Quantity,
-    };
-  }
-
-  throw new Error("Unsupported quantity");
 }
 
 export function formatRecipes(range: GoogleAppsScript.Spreadsheet.Range) {

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -1,5 +1,5 @@
 import { RECIPE_SHEET_NAME, RECIPE_SHEET_RANGE } from "./init";
-import { MixedQuantities } from "./quantities";
+import { Quantity } from "./quantities";
 
 export type Recipe = {
   name: string;
@@ -9,7 +9,7 @@ export type Recipe = {
 
 export type Ingredient = {
   name: string;
-  quantity: MixedQuantities;
+  quantity?: Quantity;
 };
 
 export function sortAndFormatRecipes() {
@@ -51,7 +51,7 @@ function readRecipes(range: GoogleAppsScript.Spreadsheet.Range): Recipe[] {
     } else {
       recipes[recipes.length - 1].ingredients.push({
         name: row[1],
-        quantity: MixedQuantities.parse(row[2]),
+        quantity: Quantity.parse(row[2]),
       });
     }
   }
@@ -62,7 +62,7 @@ function readRecipes(range: GoogleAppsScript.Spreadsheet.Range): Recipe[] {
 function writeRecipes(range: GoogleAppsScript.Spreadsheet.Range, recipes: Recipe[]) {
   const values = recipes.flatMap(recipe => ([
     [recipe.name, '', recipe.people],
-    ...recipe.ingredients.map(ingredient => (['', ingredient.name, ingredient.quantity.toString()]))
+    ...recipe.ingredients.map(ingredient => (['', ingredient.name, ingredient.quantity?.toString() || '']))
   ]));
 
   const blank = new Array(range.getNumRows() - values.length).fill(['', '', '']);
@@ -83,7 +83,7 @@ export function resizeRecipe(recipe: Recipe, people: `${number}p`): Recipe {
     people,
     ingredients: recipe.ingredients.map(ingredient => ({
       ...ingredient,
-      quantity: ingredient.quantity.multiply(ratio),
+      quantity: ingredient.quantity?.multiply(ratio),
     })),
   };
 }

--- a/src/recipe.ts
+++ b/src/recipe.ts
@@ -93,17 +93,3 @@ export function formatRecipes(range: GoogleAppsScript.Spreadsheet.Range) {
   const fontSizes = values.map(row => row.map(_ => row[0] ? 16 : 10));
   range.setFontSizes(fontSizes);
 }
-
-export function listIngredientsWithMultipleDimensions(recipes: Recipe[]): Ingredient[] {
-  return Object.values(recipes
-    .flatMap(recipe => recipe.ingredients)
-    .reduce((ingredientsByName, ingredient) => ({
-      ...ingredientsByName,
-      [ingredient.name]: {
-        ...ingredient,
-        quantity: ingredientsByName[ingredient.name]
-          ? ingredientsByName[ingredient.name].quantity.add(ingredient.quantity)
-          : ingredient.quantity,
-      },
-    }), {} as Record<string, Ingredient>)).filter(ingredient => ingredient.quantity.dimensions().length > 1);
-}

--- a/src/stores.spec.ts
+++ b/src/stores.spec.ts
@@ -1,5 +1,5 @@
 import { getStoreNames, getStoreArticles } from "./stores";
-import { MixedQuantities } from "./quantities";
+import { Quantity } from "./quantities";
 
 jest.mock("./init", () => {
   const originalModule = jest.requireActual("./init");
@@ -189,7 +189,7 @@ describe("stores", () => {
           price: {
             value: 4,
             currency: "€",
-            quantity: MixedQuantities.from(1),
+            quantity: Quantity.from(1),
           },
         },
         "Fromage": {
@@ -198,7 +198,7 @@ describe("stores", () => {
           price: {
             value: 5,
             currency: "€",
-            quantity: MixedQuantities.from(1),
+            quantity: Quantity.from(1),
           },
         },
       });

--- a/src/stores.spec.ts
+++ b/src/stores.spec.ts
@@ -160,7 +160,7 @@ describe("stores", () => {
 
           if (range === "A3:Y") {
             return createRangeFromValues([
-              ["Yaourt", "01. Produits Laitiers", "3€", "04. Produits Laitiers", "4€", "", ""],
+              [{ value: "Yaourt", note: "1.03kg/1l" }, "01. Produits Laitiers", "3€", "04. Produits Laitiers", "4€", "", ""],
               ["Lait", "01. Produits Laitiers", "3€", "", "", "", ""],
               ["Fromage", "", "", "04. Produits Laitiers", "5€", "", ""],
             ]);
@@ -189,7 +189,11 @@ describe("stores", () => {
           price: {
             value: 4,
             currency: "€",
-            quantity: Quantity.from(1),
+            quantity: Quantity.from(1, "", new Map([
+              ["mass", new Map([
+                ["volume", [Quantity.from(1.03, "kg"), Quantity.from(1, "l")]],
+              ])],
+            ])),
           },
         },
         "Fromage": {
@@ -209,13 +213,22 @@ describe("stores", () => {
 });
 
 function createRangeFromValues(initialValues: any[][]): GoogleAppsScript.Spreadsheet.Range {
-  let values = initialValues;
+  let values = initialValues.map(row => row.map(cell => {
+    return typeof cell.value === "string" && typeof cell.note === "string" ? cell.value : cell;
+  }));
+
+  let notes = initialValues.map(row => row.map(cell => {
+    return typeof cell.value === "string" && typeof cell.note === "string" ? cell.note : "";
+  }));
 
   const range = {
     getNumRows: () => values.length,
     getValues: () => values,
+    getNotes: () => notes,
     getValue: () => values[0][0],
+    getNote: () => notes[0][0],
     setValues: (newValues: any[][]) => { values = newValues },
+    setNotes: (newNotes: any[][]) => { notes = newNotes },
   } as Partial<GoogleAppsScript.Spreadsheet.Range>;
 
   return range as any;

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -28,10 +28,13 @@ export function getStoreArticles(spreadsheet: GoogleAppsScript.Spreadsheet.Sprea
   const storeIndex = 1 + 2 * getStoreNames(spreadsheet).findIndex(name => name === storeName);
   if (storeIndex < 0) return {};
 
-  return Object.fromEntries(storeSheet.getRange("A3:Y").getValues().flatMap(row => {
+  const range = storeSheet.getRange("A3:Y");
+  const notes = range.getNotes();
+
+  return Object.fromEntries(range.getValues().flatMap((row, rowIndex) => {
     const name: string = row[0];
     const department: string = row[storeIndex];
-    const price = row[storeIndex + 1] ? parsePrice(row[storeIndex + 1]) : undefined;
+    const price = row[storeIndex + 1] ? parsePrice(row[storeIndex + 1], notes[rowIndex][0]) : undefined;
 
     if (name && department) return [[name, {
       name,


### PR DESCRIPTION
Handle conversion between different units (by maintaining equivalences in Google Spreadsheets notes, e.g. "20g / 1 slice") so that we can always calculate the final price of a recipe.